### PR TITLE
Add an option to force future annotations imports on all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ Verifies python 3.7+ files use `from __future__ import annotations` if a type is
 
 Pairs well with [pyupgrade](https://github.com/asottile/pyupgrade) with the `--py37-plus` flag or higher, since pyupgrade only replaces type annotations with the PEP 563 rules if `from __future__ import annotations` is present.
 
-For example:
+## flake8 codes
+
+| Code  | Description                                                               |
+|-------|---------------------------------------------------------------------------|
+| FA100 | Missing import if a type used in the module can be rewritten using PEP563 |
+| FA101 | Missing import when no rewrite using PEP563 is available (see config)     |
+
+## Example
 
 ```python
 import typing as t
@@ -34,3 +41,9 @@ def function(a_dict: dict[str, int | None]) -> None:
     a_list: list[str] = []
     a_list.append("hello")
 ```
+
+## Configuration
+
+This plugin has a single configuration which is the `--force-future-annotations` option.
+
+If set, missing `from __future__ import annotations` will be reported regardless of a rewrite available according to PEP 563; in this case, code FA101 is used instead of FA100.

--- a/flake8_future_annotations/checker.py
+++ b/flake8_future_annotations/checker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from typing import Any, Iterator
 
-# The code F is required in order for errors to appear.
+# The code FA is required in order for errors to appear.
 ERROR_MESSAGE_100 = "FA100 Missing from __future__ import annotations but imports: {}"
 ERROR_MESSAGE_101 = "FA101 Missing from __future__ import annotations"
 SIMPLIFIABLE_TYPES = (
@@ -85,6 +85,19 @@ class FutureAnnotationsChecker:
         self.tree = tree
         self.filename = filename
 
+    @classmethod
+    def parse_options(cls, options: Any) -> None:
+        cls.force_future_annotations = options.force_future_annotations
+
+    @staticmethod
+    def add_options(option_manager: Any) -> None:
+        option_manager.add_option(
+            "--force-future-annotations",
+            action="store_true",
+            parse_from_config=True,
+            help="Force the use of from __future__ import annotations in all files.",
+        )
+
     def run(self) -> Iterator[tuple[int, int, str, type]]:
         visitor = FutureAnnotationsVisitor()
         visitor.visit(self.tree)
@@ -100,16 +113,3 @@ class FutureAnnotationsChecker:
 
         if message is not None:
             yield lineno, char_offset, message, type(self)
-
-    @staticmethod
-    def add_options(option_manager: Any) -> None:
-        option_manager.add_option(
-            "--force-future-annotations",
-            action="store_true",
-            parse_from_config=True,
-            help="Force the use of from __future__ import annotations in all files.",
-        )
-
-    @classmethod
-    def parse_options(cls, options: Any) -> None:
-        cls.force_future_annotations = options.force_future_annotations

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ flake8_future_annotations = py.typed
 
 [options.entry_points]
 flake8.extension =
-    F = flake8_future_annotations.checker:FutureAnnotationsChecker
+    FA = flake8_future_annotations.checker:FutureAnnotationsChecker
 
 [mypy]
 strict = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,12 @@ from pathlib import Path
 from flake8_future_annotations.checker import FutureAnnotationsChecker
 
 
-def run_validator_for_test_file(filename: str) -> list[tuple[int, int, str, type]]:
+def run_validator_for_test_file(
+    filename: str, force_future_annotations: bool
+) -> list[tuple[int, int, str, type]]:
     raw_content = Path(filename).read_text(encoding="utf-8")
     tree = ast.parse(raw_content)
 
     checker = FutureAnnotationsChecker(tree=tree, filename=filename)
+    checker.force_future_annotations = force_future_annotations
     return list(checker.run())

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -22,7 +22,7 @@ def test_version() -> None:
 @pytest.mark.parametrize("filepath", ALL_TEST_FILES)
 def test_ok_cases_produces_no_errors(filepath: str) -> None:
     if "ok" in filepath:
-        errors = run_validator_for_test_file(str(filepath))
+        errors = run_validator_for_test_file(str(filepath), False)
 
         assert len(errors) == 0, (str(filepath), errors)
 
@@ -30,6 +30,29 @@ def test_ok_cases_produces_no_errors(filepath: str) -> None:
 @pytest.mark.parametrize("filepath", ALL_TEST_FILES)
 def test_file_missing_future_import(filepath: str) -> None:
     if "ok" not in filepath:
-        errors = run_validator_for_test_file(str(filepath))
+        errors = run_validator_for_test_file(str(filepath), False)
 
         assert len(errors) == 1, (str(filepath), errors)
+        assert errors[0][2][:5] == "FA100", (str(filepath), "error code")
+
+
+@pytest.mark.parametrize("filepath", ALL_TEST_FILES)
+def test_ok_cases_produces_no_errors_with_force_future_annotations(
+    filepath: str,
+) -> None:
+    if "uses_future" in filepath:
+        errors = run_validator_for_test_file(str(filepath), True)
+
+        assert len(errors) == 0, (str(filepath), errors)
+
+
+@pytest.mark.parametrize("filepath", ALL_TEST_FILES)
+def test_file_missing_future_import_with_force_future_annotations(
+    filepath: str,
+) -> None:
+    if "uses_future" not in filepath:
+        errors = run_validator_for_test_file(str(filepath), True)
+        expected_code = "FA101" if "ok" in filepath else "FA100"
+
+        assert len(errors) == 1, (str(filepath), errors)
+        assert errors[0][2][:5] == expected_code, (str(filepath), "error code")


### PR DESCRIPTION
Hello,

This PR adds an optional flag `--force-future-annotations` (or config parameter).

If provided, the plugin also reports files missing the `from __future__ import annotations` import even if PEP 563 would not have allowed to rewrite anything. In that case, code FA101 is used instead of FA100.

This allows to make sure that all linted files include the future import, which one may want for consistency.

Of course, feel free to suggest any changes :slightly_smiling_face: 