### PR TITLE
Ensure unrelated as-name imports don't result in false positives

### DIFF
--- a/flake8_future_annotations/checker.py
+++ b/flake8_future_annotations/checker.py
@@ -54,8 +54,9 @@ class FutureAnnotationsVisitor(ast.NodeVisitor):
         for alias in node.names:
             if alias.name == "typing":
                 self.typing_aliases.append("typing")
-            if alias.asname is not None:
-                self.typing_aliases.append(alias.asname)
+
+                if alias.asname is not None:
+                    self.typing_aliases.append(alias.asname)
 
         self.generic_visit(node)
 

--- a/tests/test_files/ok_has_unrelated_asname_import.py
+++ b/tests/test_files/ok_has_unrelated_asname_import.py
@@ -1,0 +1,3 @@
+import blah as blah2
+
+x: blah2.Dict[str] = 42


### PR DESCRIPTION
Previously the checking of as-name imports wasn't limited to those which originated in the `typing` module. This commit fixes that and adds a test.

Fixes https://github.com/TylerYep/flake8-future-annotations/issues/13